### PR TITLE
Show tab close button

### DIFF
--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -20,7 +20,7 @@
     margin: 0 !important;
 }
 
-.tab-label-container {
+.tab-label-container, .tab-close-button {
     display: inline-block !important;
 }
 


### PR DESCRIPTION
Thanks for creating this mod. It's really useful since Zen removed this feature from the browser. Though I found it a bit annoying that the close button wasn't there. I found `.tab-close-button` was set to `display: none` by the Zen settings style because the tab bar is set to collapsed.