### PR TITLE
Fix macOS window buttons visibility

### DIFF
--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -22,8 +22,6 @@
                 overflow: visible !important;
 
                 #zen-appcontent-navbar-container {
-                    margin-left: calc(0px - var(--zen-toolbox-max-width)) !important;
-
                     #nav-bar-customization-target > toolbarbutton:first-child {
                         padding-inline-start: var(--toolbarbutton-outer-padding) !important;
                     }

--- a/sidebar-expand-on-hover/preferences.json
+++ b/sidebar-expand-on-hover/preferences.json
@@ -33,12 +33,12 @@
       "property": "theme.sidebar_expand_on_hover.expanded_width",
       "label": "Width of the expanded sidebar",
       "type": "string",
-      "defaultValue": "300px"
+      "defaultValue": "350px"
     },
     {
       "property": "theme.sidebar_expand_on_hover.transition_speed",
       "label": "Transition speed of the sidebar",
       "type": "string",
-      "defaultValue": "120ms"
+      "defaultValue": "100ms"
     }
   ]


### PR DESCRIPTION
This fixes the macOS Windows Buttons (#24) from being missing, at least testing from several different setups that I've done. Did not test this change against a Windows or Linux machine.

I can remove the preference default value updates as well, but felt like those were slightly better defaults.

Pre-change appearance:
![zen-hover-mod-bad](https://github.com/user-attachments/assets/2dff19df-3078-4542-a8a0-9f7f035a2d21)

Post-change appearance:
![zen-hover-mod-fixed](https://github.com/user-attachments/assets/4ea0da5c-4b38-4ebf-80e3-2457825b5e00)