### PR TITLE
making Bubbls Smaller When Sidebar is Closed

### DIFF
--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -103,6 +103,7 @@
 
                 .tab-content {
                     min-width: 0 !important;
+                    padding-left: 12px !important;
                 }
 
                 @media not (-moz-bool-pref: "theme.sidebar_expand_on_hover.default_tab_background_shape") {
@@ -319,6 +320,7 @@
     #zen-sidebar-bottom-buttons {
         display: flex !important;
         flex-direction: row !important;
+        padding-left: 0px !important;
     }
     #zen-sidebar-bottom-buttons > * {
         flex-grow: 1 !important;
@@ -331,6 +333,7 @@
         flex-direction: column;
         max-width: 100% !important;
         overflow: hidden;
+        padding-left: 0px !important;
       }
     #tabbrowser-tabs[orient="vertical"] {
         overflow: hidden;
@@ -338,6 +341,6 @@
         box-sizing: border-box;
     }
     #navigator-toolbox:not([zen-has-hover], [has-popup-menu], [movingtab]) vbox.tab-background {
-        width: 80% !important;
+        width: 90% !important;
     }
 }

--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -129,7 +129,7 @@
     }
 
     @media (-moz-bool-pref: "theme.sidebar_expand_on_hover.hide_workspace_indicator") {
-        #zen-current-workspace-indicator {
+        #zen-current-workspace-indicator-container {
             display: none !important;
         }
     }

--- a/sidebar-expand-on-hover/chrome.css
+++ b/sidebar-expand-on-hover/chrome.css
@@ -337,4 +337,7 @@
         max-width: 100%;
         box-sizing: border-box;
     }
+    #navigator-toolbox:not([zen-has-hover], [has-popup-menu], [movingtab]) vbox.tab-background {
+        width: 80% !important;
+    }
 }


### PR DESCRIPTION
without this commit:
![2025-02-26-185020_hyprshot](https://github.com/user-attachments/assets/e6399230-2828-46c3-b69b-c1175d0119d6)
after:
![2025-02-26-185034_hyprshot](https://github.com/user-attachments/assets/9a85062a-5e5d-4883-9620-dba2e46d1e86)
without zen-mods enabled: 
![2025-02-26-185230_hyprshot](https://github.com/user-attachments/assets/1daf679e-5a1e-4fd8-88cb-c3670ccfcc46)

remaining issue with plugin:
![2025-02-26-185305_hyprshot](https://github.com/user-attachments/assets/52a5fc98-4797-46b0-8652-61acd0e67057)
 "Now playing indicator (v1.2.1)" plugins side bar is not placed right